### PR TITLE
feat: first draft of the client class

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ npm install --save @system76/js-api
 ```
 
 ```js
-import Api from '@system76/js-api'
+import { Client } from '@system76/js-api'
 
-const api = new Api({
+const api = new Client({
   baseUrl: 'https://api-v2.system76.com',
   token: () => 'testingtoken'
 })
 
-const { data } = await api.get('/catalog/products')
+const { data } = await api.get('/catalog/products').jsonApi()
 ```
 
 ### Nuxt
@@ -75,10 +75,10 @@ export default {
 Put this in your `~/plugins/api.js`:
 
 ```js
-import Api from '@system76/js-api'
+import { Client } from '@system76/js-api'
 
 export default function (ctx, inject) {
-  const api = new Api({
+  const api = new Client({
     baseUrl: 'https://api-v2.system76.com',
     token: () => ctx.store.getters.token
   })
@@ -93,8 +93,22 @@ can do:
 ```js
 export default {
   asyncData: async ({ $api }) => ({
-    products: await $api.get('/catalog/products').data
+    products: await $api.get('/catalog/products').jsonApi().flatten()
   })
+}
+```
+
+or:
+
+```js
+export default {
+  methods: {
+    async create () {
+      const { data: products } = await $api.get('/catalog/products')
+        .jsonApi()
+        .page(2)
+    }
+  }
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -720,6 +720,24 @@
         "resolve": "^1.12.0"
       }
     },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1303,6 +1321,12 @@
         "is-error": "^2.2.0"
       }
     },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+      "dev": true
+    },
     "cosmiconfig": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
@@ -1630,6 +1654,26 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -2384,6 +2428,23 @@
         "reusify": "^1.0.4"
       }
     },
+    "fetch-mock": {
+      "version": "9.10.3",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.10.3.tgz",
+      "integrity": "sha512-vvTW3vu+6sgDuOpInd8VtaaYlt56Un/zrEvBmT8JppDXj2ZY3PQgIAoxqdSAFR5o/10jJ1yFBhXLQ/Dce/p+jg==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -2676,6 +2737,12 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
     },
     "global-dirs": {
       "version": "2.0.1",
@@ -3279,10 +3346,22 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
     "is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
       "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
       "dev": true
     },
     "is-symbol": {
@@ -3335,6 +3414,16 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
     },
     "js-string-escape": {
       "version": "1.0.1",
@@ -3470,13 +3559,24 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
       "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "log-symbols": {
@@ -3715,6 +3815,16 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -4056,6 +4166,12 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
+    },
     "path-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -4228,6 +4344,12 @@
         "escape-goat": "^2.0.0"
       }
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -4320,6 +4442,12 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -5169,6 +5297,15 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "trim-off-newlines": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
@@ -5439,11 +5576,34 @@
         "defaults": "^1.0.3"
       }
     },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
     "well-known-symbols": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
       "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
       "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz",
+      "integrity": "sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,21 @@
     "ava": "^3.5.1",
     "commitizen": "^4.0.4",
     "cz-conventional-changelog": "^3.1.0",
-    "eslint": "^7.4.0"
+    "eslint": "^7.4.0",
+    "fetch-mock": "^9.10.3",
+    "isomorphic-fetch": "^2.2.1"
+  },
+  "ava": {
+    "require": [
+      "./test/_setup.js"
+    ]
   },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "dependencies": {
+    "lodash": "^4.17.19"
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -1,0 +1,268 @@
+import {
+  camelCase,
+  combinePaths,
+  kebabCase,
+  recursive,
+  snakeCase
+} from './utility.js'
+
+const JSON_HEADER = 'application/json'
+const JSON_API_HEADER = 'application/vnd.api+json'
+const DEFAULT_USER_AGENT = 'js-api (https://github.com/system76/js-api)'
+
+async function decodeResponse (response) {
+  const contentType = response.headers.get('content-type') || []
+  const isJson = (
+    contentType.includes(JSON_HEADER) ||
+    contentType.includes(JSON_API_HEADER)
+  )
+
+  if (isJson) {
+    return response.json()
+  } else if (response.body != null) {
+    return response.text()
+  } else {
+    return null
+  }
+}
+
+export default class Client {
+  constructor (options) {
+    this._baseUrl = new URL(options.baseUrl)
+
+    this._method = 'GET'
+    this._path = '/'
+
+    this._cache = true
+    this._isJsonApi = false
+    this._token = options.token
+    this._headers = {
+      Accept: JSON_HEADER,
+      'Content-Type': JSON_HEADER,
+      'User-Agent': options.userAgent || DEFAULT_USER_AGENT
+    }
+
+    this._parameters = {}
+    this._includes = []
+    this._body = null
+
+    this._flatten = false
+  }
+
+  include (include) {
+    this._includes = this._includes
+      .filter((i) => !include.startsWith(i))
+
+    if (!this._includes.find((r) => r.startsWith(include))) {
+      this._includes.push(include)
+    }
+
+    return this
+  }
+
+  header (key, value) {
+    if (value == null) {
+      delete this._headers[key]
+    } else {
+      this._headers[key] = value
+    }
+
+    return this
+  }
+
+  authentication (value) {
+    this._token = value
+  }
+
+  parameter (key, value) {
+    if (value === undefined) {
+      delete this._parameters[key]
+    } else if (value === null) {
+      this._parameters[key] = ''
+    } else {
+      this._parameters[key] = value
+    }
+
+    return this
+  }
+
+  page (number) {
+    return this.parameter('page[number]', number)
+  }
+
+  size (size) {
+    return this.parameter('page[size]', size)
+  }
+
+  cache (value = true) {
+    this._cache = value
+
+    return this
+  }
+
+  jsonApi (value = true) {
+    this._isJsonApi = value
+
+    return this
+  }
+
+  body (value) {
+    this._body = value
+
+    return this
+  }
+
+  get (path) {
+    this._method = 'GET'
+    this._path = path
+
+    return this
+  }
+
+  post (path) {
+    this._method = 'POST'
+    this._path = path
+
+    return this
+  }
+
+  patch (path) {
+    this._method = 'PATCH'
+    this._path = path
+
+    return this
+  }
+
+  put (path) {
+    this._method = 'PUT'
+    this._path = path
+
+    return this
+  }
+
+  delete (path) {
+    this._method = 'DELETE'
+    this._path = path
+
+    return this
+  }
+
+  flatten (value = true) {
+    this._flatten = value
+
+    return this
+  }
+
+  createIncludes () {
+    const params = new URLSearchParams()
+
+    if (this._isJsonApi) {
+      const values = this._includes
+        .map((v) => v.split('.').map(kebabCase).join('.'))
+        .map(encodeURIComponent)
+        .join(',')
+
+      params.set('include', values)
+    } else {
+      this._includes
+        .map(snakeCase)
+        .forEach((v) => params.set('include[]', v))
+    }
+
+    return params
+  }
+
+  createParameters () {
+    const params = new URLSearchParams()
+
+    Object.keys(this._parameters).forEach((key) => {
+      params.set(key, this._parameters[key])
+    })
+
+    return params
+  }
+
+  createUrl () {
+    const url = (this._baseUrl.pathname === '/')
+      ? new URL(this._path, this._baseUrl)
+      : new URL(combinePaths(this._baseUrl.pathname, this._path), this._baseUrl)
+
+    const params = new URLSearchParams()
+
+    if (this._includes.length > 0) {
+      for (var [ik, iv] of this.createIncludes().entries()) {
+        params.set(ik, iv)
+      }
+    }
+
+    if (Object.keys(this._parameters).length > 0) {
+      for (var [pk, pv] of this.createParameters().entries()) {
+        params.set(pk, pv)
+      }
+    }
+
+    url.search = params.toString()
+    return url.toString()
+  }
+
+  createHeaders () {
+    const headers = new Headers(this._headers)
+
+    if (this._token) {
+      const token = (typeof this._token === 'function') ? this._token() : this._token
+      headers.append('authorization', token)
+    }
+
+    if (this._isJsonApi) {
+      headers.set('accept', JSON_API_HEADER)
+      headers.set('content-type', JSON_API_HEADER)
+    }
+
+    return headers
+  }
+
+  createBody () {
+    if (this._body == null) {
+      return null
+    } else if (typeof this._body === 'object') {
+      if (this._isJsonApi) {
+        return JSON.stringify(recursive(this._body, kebabCase))
+      } else {
+        return JSON.stringify(recursive(this._body, snakeCase))
+      }
+    } else {
+      return this._body
+    }
+  }
+
+  createRequest () {
+    return {
+      method: this._method.toUpperCase(),
+      headers: this.createHeaders(),
+      body: this.createBody(),
+      cache: (this._cache) ? 'default' : 'no-cache',
+      redirect: 'follow'
+    }
+  }
+
+  then (resolve, reject) {
+    return fetch(this.createUrl(), this.createRequest())
+      .then(this.parseResponse.bind(this))
+      .then((res) => (this._flatten) ? res.data : res)
+      .then(resolve, reject)
+  }
+
+  async parseResponse (response) {
+    let body = await decodeResponse(response)
+
+    if (body != null && typeof body === 'object') {
+      body = recursive(body, camelCase)
+    }
+
+    if (response.ok) {
+      return { data: body }
+    } else {
+      throw new Error(`ApiError: (${response.status}) ${response.statusText}`)
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,1 @@
-export default function (options) {
-  return options
-}
+export Client from './client'

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,0 +1,46 @@
+import camelCase from 'lodash/camelCase.js'
+import isPlainObject from 'lodash/isPlainObject.js'
+import kebabCase from 'lodash/kebabCase.js'
+import lodashSnakeCase from 'lodash/snakeCase.js'
+
+export { camelCase, kebabCase }
+
+// Fixes converting `testValue23` to `test_value23` instead of `test_value_23`
+export function snakeCase (str) {
+  return str
+    .split('.')
+    .map(lodashSnakeCase)
+    .join('.')
+    .replace(/_([0-9]+)/igm, '$1')
+}
+
+export function recursive (obj, fn) {
+  if (isPlainObject(obj) === false) {
+    return obj
+  }
+
+  const out = {}
+
+  for (const key of Object.keys(obj)) {
+    const newKey = fn(key)
+
+    if (isPlainObject(obj[key])) {
+      out[newKey] = recursive(obj[key], fn)
+    } else if (Array.isArray(obj[key])) {
+      out[newKey] = obj[key].map((v) => recursive(v, fn))
+    } else {
+      out[newKey] = obj[key]
+    }
+  }
+
+  return out
+}
+
+export function combinePaths (...paths) {
+  return paths
+    .filter((p) => (p != null))
+    .map((p) => p.trim())
+    .map((p, i) => (i !== 0) ? p.replace(/^[/]+/, '') : p)
+    .map((p, i, a) => (i !== a.length - 1) ? p.replace(/[/]+$/, '') : p)
+    .join('/')
+}

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -1,0 +1,1 @@
+import 'isomorphic-fetch'

--- a/test/client-integration.js
+++ b/test/client-integration.js
@@ -1,0 +1,83 @@
+import test from 'ava'
+import fetchMock from 'fetch-mock'
+
+import Client from '../src/client.js'
+
+const HOST = 'http://example.com'
+
+test.beforeEach((t) => {
+  t.context.path = `/${Math.random().toString(36).substring(2, 15)}`
+  t.context.url = `${HOST}${t.context.path}`
+
+  t.context.client = new Client({ baseUrl: HOST })
+})
+
+test('token option can be a function to get resolved', async (t) => {
+  fetchMock.get({
+    url: t.context.url,
+    headers: { authorization: 'test' }
+  }, 200)
+
+  const client = new Client({
+    baseUrl: HOST,
+    token: () => 'test'
+  })
+
+  await t.notThrowsAsync(() => client.get(t.context.path))
+})
+
+test('202 status codes return null data', async (t) => {
+  fetchMock.get(t.context.url, 202)
+  const res = await t.context.client.get(t.context.path)
+  t.is(res.data, null)
+})
+
+test('200 with no body returns null data', async (t) => {
+  fetchMock.get(t.context.url, 200)
+  const res = await t.context.client.get(t.context.path)
+  t.is(res.data, null)
+})
+
+test('200 returns text for non json responses', async (t) => {
+  fetchMock.get(t.context.url, {
+    body: 'test',
+    status: 200
+  })
+
+  const res = await t.context.client.get(t.context.path)
+  t.is(res.data, 'test')
+})
+
+test('200 returns JSON object response', async (t) => {
+  fetchMock.get(t.context.url, {
+    body: { type: 'test' },
+    status: 200
+  })
+
+  const res = await t.context.client.get(t.context.path)
+  t.is(res.data.type, 'test')
+})
+
+test('camel cases response json', async (t) => {
+  fetchMock.get(t.context.url, {
+    body: {
+      'test-key-value-prop-test': 'test',
+      test_even_more_types: 'test'
+    },
+    status: 200
+  })
+
+  const res = await t.context.client.get(t.context.path)
+  t.is(res.data.testKeyValuePropTest, 'test')
+  t.is(res.data.testEvenMoreTypes, 'test')
+})
+
+test('flatten returns the data on async', async (t) => {
+  fetchMock.get(t.context.url, {
+    body: { key: 'value' },
+    status: 200
+  })
+
+  const res = await t.context.client.get(t.context.path).flatten()
+  t.is(res.key, 'value')
+})

--- a/test/client.js
+++ b/test/client.js
@@ -1,0 +1,79 @@
+import test from 'ava'
+
+import Client from '../src/client.js'
+
+test.beforeEach((t) => {
+  t.context.client = new Client({ baseUrl: 'http://localhost' })
+})
+
+test.afterEach((t) => {
+  t.log(t.context.client.createUrl())
+})
+
+test('constructor accepts protocol', (t) => {
+  const client = new Client({ baseUrl: 'wss://localhost' })
+  t.true(client.createUrl().includes('wss://'))
+})
+
+test('constructor accepts host', (t) => {
+  const client = new Client({ baseUrl: 'https://example.com' })
+  t.true(client.createUrl().includes('example.com'))
+})
+
+test('constructor accepts port', (t) => {
+  const client = new Client({ baseUrl: 'https://localhost:1234' })
+  t.true(client.createUrl().includes('1234'))
+})
+
+test('constructor accepts a url to prefix with', (t) => {
+  const client = new Client({ baseUrl: 'https://example.com/api/v2/' })
+  t.true(client.createUrl().includes('/api/v2'))
+})
+
+test('include only includes the longest relationship', (t) => {
+  const client = t.context.client.include('test').include('test.product')
+  t.true(client._includes.includes('test.product'))
+  t.false(client._includes.includes('test'))
+})
+
+test('header sets a header key', (t) => {
+  t.context.client.header('test', 'value!')
+  t.is(t.context.client._headers.test, 'value!')
+  t.context.client.header('test', null)
+  t.is(t.context.client._headers.test, undefined)
+})
+
+test('authentication sets the token value', (t) => {
+  t.context.client.authentication('testing')
+  t.is(t.context.client._token, 'testing')
+})
+
+test('parameter sets parameters parameters', (t) => {
+  t.context.client.parameter('testing[value]', 'test')
+  t.is(t.context.client.createParameters().get('testing[value]'), 'test')
+  t.context.client.parameter('testing[value]', null)
+  t.is(t.context.client.createParameters().get('testing[value]'), '')
+  t.context.client.parameter('testing[value]', undefined)
+  t.is(t.context.client.createParameters().get('testing[value]'), null)
+})
+
+test('body sets the request body', (t) => {
+  t.context.client.body({ data: 'value' })
+  t.is(t.context.client._body.data, 'value')
+})
+
+test('include adds an array field to url', (t) => {
+  const client = t.context.client.include('product')
+  t.true(client.createUrl().includes('include%5B%5D=product'))
+})
+
+test('include with JSON API adds dot notated string to url', (t) => {
+  const client = t.context.client.jsonApi().include('test.productThing.Fun')
+  t.true(client.createUrl().includes('include=test.product-thing.fun'))
+})
+
+test('get sets the method and path', (t) => {
+  const client = t.context.client.get('/test')
+  t.true(client.createUrl().endsWith('/test'))
+  t.is(client.createRequest().method, 'GET')
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,0 @@
-import test from 'ava'
-
-test('it works', (t) => {
-  t.pass()
-})

--- a/test/utility.js
+++ b/test/utility.js
@@ -1,0 +1,33 @@
+import test from 'ava'
+
+import * as utility from '../src/utility.js'
+
+test('snake case does not seperate numbers from text', (t) => {
+  t.is(utility.snakeCase('testValue123'), 'test_value123')
+})
+
+test('recursive modifies key values deep in an object', (t) => {
+  const input = {
+    key: {
+      deep_key: {
+        deepist_key: 'test'
+      }
+    }
+  }
+
+  t.deepEqual(utility.recursive(input, (k) => 'test'), {
+    test: {
+      test: {
+        test: 'test'
+      }
+    }
+  })
+})
+
+test('combinePaths strips duplicate slashes', (t) => {
+  t.is(utility.combinePaths('/test/', '/more/', '/stuff/'), '/test/more/stuff/')
+})
+
+test('combinePaths removes null values', (t) => {
+  t.is(utility.combinePaths('/test/', null, '/value/'), '/test/value/')
+})


### PR DESCRIPTION
This is mostly a pull from tachi but with some stuff removed and cleaned up. Instead of relying on custom functions, we lean on `URL`, `URLSearchParams`, and `Headers`. Less magic for transforming params. This doesn't handle JSON API responses as nicely as I want, but that can come in a later PR. It also does not handle errors as well as I want, but that will come next.