### PR TITLE
fix: do not use esm modules due to webpack issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,6 @@ Add these fields to your `nuxt.config.js` file:
 
 ```js
 export default {
-  build: {
-    transpile: [
-      '@system76/js-api'
-    ]
-  },
-
   plugins: [
     `~/plugins/api`
   ]
@@ -80,7 +74,7 @@ import { Client } from '@system76/js-api'
 export default function (ctx, inject) {
   const api = new Client({
     baseUrl: 'https://api-v2.system76.com',
-    token: () => ctx.store.getters.token
+    token: () => `Token ${ctx.store.getters.token}`
   })
 
   inject('api', api)

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "author": "System76 <hosting@system76.com> (https://system76.com)",
   "license": "GPL-3.0",
   "main": "src/index.js",
-  "module": "src/index.js",
-  "type": "module",
   "scripts": {
     "lint": "eslint --ext js,vue --ignore-path .gitignore .",
     "lint:fix": "eslint --fix --ext js,vue --ignore-path .gitignore .",

--- a/src/client.js
+++ b/src/client.js
@@ -1,10 +1,10 @@
-import {
+const {
   camelCase,
   combinePaths,
   kebabCase,
   recursive,
   snakeCase
-} from './utility.js'
+} = require('./utility.js')
 
 const JSON_HEADER = 'application/json'
 const JSON_API_HEADER = 'application/vnd.api+json'
@@ -26,7 +26,7 @@ async function decodeResponse (response) {
   }
 }
 
-export class Client {
+module.exports = class Client {
   constructor (options) {
     this._baseUrl = new URL(options.baseUrl)
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,3 @@
-export { Client } from './client'
+module.exports = {
+  Client: require('./client')
+}

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,12 +1,10 @@
-import camelCase from 'lodash/camelCase.js'
-import isPlainObject from 'lodash/isPlainObject.js'
-import kebabCase from 'lodash/kebabCase.js'
-import lodashSnakeCase from 'lodash/snakeCase.js'
-
-export { camelCase, kebabCase }
+const camelCase = require('lodash/camelCase')
+const isPlainObject = require('lodash/isPlainObject')
+const kebabCase = require('lodash/kebabCase')
+const lodashSnakeCase = require('lodash/snakeCase')
 
 // Fixes converting `testValue23` to `test_value23` instead of `test_value_23`
-export function snakeCase (str) {
+function snakeCase (str) {
   return str
     .split('.')
     .map(lodashSnakeCase)
@@ -14,7 +12,7 @@ export function snakeCase (str) {
     .replace(/_([0-9]+)/igm, '$1')
 }
 
-export function recursive (obj, fn) {
+function recursive (obj, fn) {
   if (isPlainObject(obj) === false) {
     return obj
   }
@@ -36,7 +34,7 @@ export function recursive (obj, fn) {
   return out
 }
 
-export function combinePaths (...paths) {
+function combinePaths (...paths) {
   return paths
     .filter((p) => (p != null))
     .map((p) => p.trim())
@@ -44,3 +42,5 @@ export function combinePaths (...paths) {
     .map((p, i, a) => (i !== a.length - 1) ? p.replace(/[/]+$/, '') : p)
     .join('/')
 }
+
+module.exports = { camelCase, kebabCase, snakeCase, recursive, combinePaths }

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -1,1 +1,1 @@
-import 'isomorphic-fetch'
+require('isomorphic-fetch')

--- a/test/client-integration.js
+++ b/test/client-integration.js
@@ -1,7 +1,7 @@
-import test from 'ava'
-import fetchMock from 'fetch-mock'
+const test = require('ava')
+const fetchMock = require('fetch-mock')
 
-import { Client } from '../src/client.js'
+const Client = require('../src/client')
 
 const HOST = 'http://example.com'
 

--- a/test/client.js
+++ b/test/client.js
@@ -1,6 +1,6 @@
-import test from 'ava'
+const test = require('ava')
 
-import { Client } from '../src/client.js'
+const Client = require('../src/client')
 
 test.beforeEach((t) => {
   t.context.client = new Client({ baseUrl: 'http://localhost' })

--- a/test/utility.js
+++ b/test/utility.js
@@ -1,6 +1,6 @@
-import test from 'ava'
+const test = require('ava')
 
-import * as utility from '../src/utility.js'
+const utility = require('../src/utility')
 
 test('snake case does not seperate numbers from text', (t) => {
   t.is(utility.snakeCase('testValue123'), 'test_value123')


### PR DESCRIPTION
I can't wait til the JS community has standards. Like a standard way to make modules.