### PR TITLE
feat: support default phoenix error view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
         uses: actions/checkout@v2.3.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2.1.4
         with:
-          node-version: 12.x
+          node-version: '12'
 
       - name: Install
         run: npm ci
@@ -32,9 +32,9 @@ jobs:
         uses: actions/checkout@v2.3.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2.1.4
         with:
-          node-version: 12.x
+          node-version: '12'
 
       - name: Install
         run: npm ci
@@ -56,9 +56,9 @@ jobs:
         uses: actions/checkout@v2.3.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2.1.4
         with:
-          node-version: 12.x
+          node-version: '12'
 
       - name: Deploy
         run: npx semantic-release

--- a/test/error.js
+++ b/test/error.js
@@ -56,6 +56,17 @@ test('errors includes errors without a source', (t) => {
   t.deepEqual(error.errors, ['Not authorized'])
 })
 
+test('errors includes errors from a default phoenix project', (t) => {
+  const error = new ApiError(t.context.jsonResponse, {
+    errors: {
+      detail: 'Unauthorized'
+    }
+  })
+
+  t.deepEqual(error.fields, {})
+  t.deepEqual(error.errors, ['Unauthorized'])
+})
+
 test('errors flattens field errors', (t) => {
   const error = new ApiError(t.context.jsonResponse, {
     errors: [{


### PR DESCRIPTION
Default phoenix generates an error like `{ error: { detail: 'error' } }` and we should support that by default