### PR TITLE
fix: issue with json error not nesting correctly

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -291,7 +291,7 @@ module.exports = class Client {
     }
 
     return (isJsonApi)
-      ? { data: defaultsDeep({}, body, headersBody) }
+      ? defaultsDeep({}, body, headersBody)
       : defaultsDeep({}, { data: body }, headersBody)
   }
 
@@ -299,7 +299,7 @@ module.exports = class Client {
     const body = await this.parseBody(response)
 
     if (response.ok) {
-      return body.data
+      return body
     } else {
       throw new ApiError(response, body.data)
     }

--- a/src/client.js
+++ b/src/client.js
@@ -291,17 +291,17 @@ module.exports = class Client {
     }
 
     return (isJsonApi)
-      ? defaultsDeep({}, body, headersBody)
+      ? { data: defaultsDeep({}, body, headersBody) }
       : defaultsDeep({}, { data: body }, headersBody)
   }
 
   async parseResponse (response) {
-    const body = this.parseBody(response)
+    const body = await this.parseBody(response)
 
     if (response.ok) {
-      return body
+      return body.data
     } else {
-      throw new ApiError(response, body)
+      throw new ApiError(response, body.data)
     }
   }
 }

--- a/test/client-integration.js
+++ b/test/client-integration.js
@@ -228,3 +228,28 @@ test('throws an ApiError with bad response', async (t) => {
     message: 'Internal Server Error'
   })
 })
+
+test.only('throws an ApiError with default elixir error response', async (t) => {
+  fetchMock.post({ url: t.context.url }, {
+    status: 400,
+    headers: {
+      'content-type': 'application/json; charset=utf-8'
+    },
+    body: {
+      errors: {
+        email: ["has already been taken"]
+      }
+    }
+  })
+
+  const client = new Client({ baseUrl: HOST })
+
+  const error = await t.throwsAsync(client.post(t.context.path), {
+    instanceOf: ApiError
+  })
+
+  t.is(error.message, 'email has already been taken')
+  t.deepEqual(error.fields, {
+    email: ['has already been taken']
+  })
+})

--- a/test/client-integration.js
+++ b/test/client-integration.js
@@ -229,7 +229,7 @@ test('throws an ApiError with bad response', async (t) => {
   })
 })
 
-test.only('throws an ApiError with default elixir error response', async (t) => {
+test('throws an ApiError with default elixir error response', async (t) => {
   fetchMock.post({ url: t.context.url }, {
     status: 400,
     headers: {
@@ -237,7 +237,7 @@ test.only('throws an ApiError with default elixir error response', async (t) => 
     },
     body: {
       errors: {
-        email: ["has already been taken"]
+        email: ['has already been taken']
       }
     }
   })


### PR DESCRIPTION
There was an error for regular json responses not getting error parsed correctly... Basically the body that the error class would get would depend on the header. This fixes it so any error (json or json api) will be parsed correctly.
