### PR TITLE
feat: add bodyCasing() flag

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -36,6 +36,7 @@ module.exports = class Client {
     this._method = 'GET'
     this._path = '/'
 
+    this._disableCase = false
     this._cache = true
     this._isJsonApi = false
     this._token = options.token
@@ -156,6 +157,12 @@ module.exports = class Client {
     return this
   }
 
+  disableCase (value = true) {
+    this._disableCase = value
+
+    return this
+  }
+
   createIncludes () {
     const params = new URLSearchParams()
 
@@ -231,10 +238,14 @@ module.exports = class Client {
     if (this._body == null) {
       return null
     } else if (typeof this._body === 'object') {
-      if (this._isJsonApi) {
-        return JSON.stringify(recursive(this._body, kebabCase))
+      if (this._disableCase) {
+        return JSON.stringify(this._body)
       } else {
-        return JSON.stringify(recursive(this._body, snakeCase))
+        if (this._isJsonApi) {
+          return JSON.stringify(recursive(this._body, kebabCase))
+        } else {
+          return JSON.stringify(recursive(this._body, snakeCase))
+        }
       }
     } else {
       return this._body

--- a/src/client.js
+++ b/src/client.js
@@ -36,7 +36,7 @@ module.exports = class Client {
     this._method = 'GET'
     this._path = '/'
 
-    this._disableCase = false
+    this._bodyCasing = true
     this._cache = true
     this._isJsonApi = false
     this._token = options.token
@@ -157,8 +157,8 @@ module.exports = class Client {
     return this
   }
 
-  disableCase (value = true) {
-    this._disableCase = value
+  bodyCasing (value = true) {
+    this._bodyCasing = value
 
     return this
   }
@@ -238,7 +238,7 @@ module.exports = class Client {
     if (this._body == null) {
       return null
     } else if (typeof this._body === 'object') {
-      if (this._disableCase) {
+      if (!this._bodyCasing) {
         return JSON.stringify(this._body)
       } else {
         if (this._isJsonApi) {


### PR DESCRIPTION
Introducing the `bodyCasing()` flag for those times when `snakeCase` works a little _too_ well. 

`true` _(default)_ use casing functions.
`false` disable casing functions.

usage: 
```
await this.$api()
  .post('/endpoint')
  .bodyCasing(false)
  .body({ abcde123: true })
```